### PR TITLE
Pass string manifest to registries example service

### DIFF
--- a/test/stub/registries/examples.ts
+++ b/test/stub/registries/examples.ts
@@ -20,7 +20,7 @@ export default class ExamplesConnector extends StubConnector {
         Object.entries(manifests).map(
           async ([packageName, manifest]) => ({
             package: packages[packageName],
-            manifest: await storage.predictUri(manifest)
+            manifestUri: (await storage.predictUri(manifest)).href
           })
         )
       )

--- a/test/stub/registries/service.ts
+++ b/test/stub/registries/service.ts
@@ -60,16 +60,16 @@ export default class StubConnector extends config.Connector<registries.Service> 
   optionsType = t.interface({
     releases: t.array(t.interface({
       package: t.object,
-      manifest: t.interface({ href: t.string })
+      manifestUri: t.string,
     }))
   });
 
   async init(
-    { releases }: { releases: Array<{package: pkg.Package, manifest: URL}> }
+    { releases }: { releases: Array<{package: pkg.Package, manifestUri: string}> }
   ): Promise<registries.Service> {
     const service = new StubService();
-    for (let { package: { packageName, version } , manifest } of releases) {
-      await service.publish(packageName, version, manifest);
+    for (let { package: { packageName, version } , manifestUri } of releases) {
+      await service.publish(packageName, version, new URL(manifestUri));
     }
 
     return service;


### PR DESCRIPTION
Instead of full URL object. This seems to have gotten broken somehow related to io-ts runtime checking.