### PR TITLE
Automatically validate manifests in v2 reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-next.10",
   "description": "Javascript library for EthPM (EIPs 1123 / 1319)",
   "main": "index.js",
-  "types": "main.d.ts",
+  "types": "./dist/main.d.ts",
   "scripts": {
     "test": "jest --verbose",
     "docs": "gulp docs",
@@ -59,6 +59,7 @@
     "vinyl-paths": "^2.1.0"
   },
   "dependencies": {
+    "better-module-alias": "^1.0.1",
     "bn.js": "^4.11.8",
     "debug": "^3.1.0",
     "deep-equal": "^1.0.1",

--- a/src/registries/web3/service.ts
+++ b/src/registries/web3/service.ts
@@ -188,7 +188,7 @@ export class Web3RegistryService implements registries.Service {
 }
 
 type Web3RegistryOptions = {
-  provider: Web3Provider;
+  provider: Web3EthereumProvider;
   registryAddress: string;
 };
 


### PR DESCRIPTION
Stronger validation of manifests is a useful pattern we've been using in `py-ethpm`. I added validation against the json schema in `v2.Reader`. It's been a while since I've done much js and have no experience with typescript - so pls feel free to critique this as harshly as necessary. 