### PR TITLE
Update ethpm uri parser to support default chain ids

### DIFF
--- a/src/installer/truffle/index.ts
+++ b/src/installer/truffle/index.ts
@@ -5,7 +5,6 @@
 const fs = require('fs-extra')
 const tmp = require('tmp')
 const path = require('path')
-import { Erc1319URI } from "ethpm/utils/uri"
 import { IpfsService } from "ethpm/storage/ipfs";
 import { Resolver } from "ethpm/package/resolver"
 import { URL } from "url";

--- a/src/utils/test/uri.ts
+++ b/src/utils/test/uri.ts
@@ -6,7 +6,6 @@ describe('validates URIs', () => {
     'erc1319://snakecharmers.eth',
     'erc1319://snakecharmers.eth:1',
     'erc1319://snakecharmers.eth:1/',
-    new URL('erc1319://snakecharmers.eth:1/'),
   ];
 
   test.each(validRegistryUris)(
@@ -34,9 +33,9 @@ describe('validates URIs', () => {
 
 describe('parses package names and versions', () => {
   const validPackageIdUris = [
+    'ethpm://snakecharmers.eth/dai@1.0.0',
     'ethpm://snakecharmers.eth:1/dai@1.0.0',
     'ethpm://snakecharmers.eth:1/dai@1.0.0/',
-    new URL('ethpm://snakecharmers.eth:1/dai@1.0.0/'),
   ];
 
   test.each(validPackageIdUris)(
@@ -62,9 +61,9 @@ describe('parses package names and versions', () => {
 
 describe('supports namespaced assets', () => {
   const validPackageIdUris = [
+    'ethpm://snakecharmers.eth/dai@1.0.0/deployments/DSToken',
     'ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken',
     'ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken/',
-    new URL('ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken/'),
   ];
 
   test.each(validPackageIdUris)(

--- a/src/utils/test/uri.ts
+++ b/src/utils/test/uri.ts
@@ -1,7 +1,8 @@
-import { Erc1319URI } from 'ethpm/utils/uri';
+import { EthpmURI } from 'ethpm/utils/uri';
 
 describe('validates URIs', () => {
   const validRegistryUris = [
+    'erc1319://snakecharmers.eth',
     'erc1319://snakecharmers.eth:1',
     'erc1319://snakecharmers.eth:1/',
   ];
@@ -9,17 +10,19 @@ describe('validates URIs', () => {
   test.each(validRegistryUris)(
     'for valid registry URIs',
     (uri) => {
-      const erc1319URI = new Erc1319URI(uri);
-      expect(erc1319URI).toHaveProperty('scheme');
-      expect(erc1319URI).toHaveProperty('address');
-      expect(erc1319URI).toHaveProperty('chainId');
-      expect(erc1319URI).toHaveProperty('packageName');
-      expect(erc1319URI).toHaveProperty('version');
-      expect(erc1319URI.scheme).toEqual('erc1319');
-      expect(erc1319URI.address).toEqual('snakecharmers.eth');
-      expect(erc1319URI.chainId).toEqual(1);
-      expect(erc1319URI.packageName).toEqual('');
-      expect(erc1319URI.version).toEqual('');
+      const ethpmURI = new EthpmURI(uri);
+      expect(ethpmURI).toHaveProperty('scheme');
+      expect(ethpmURI).toHaveProperty('address');
+      expect(ethpmURI).toHaveProperty('chainId');
+      expect(ethpmURI).toHaveProperty('packageName');
+      expect(ethpmURI).toHaveProperty('version');
+      expect(ethpmURI).toHaveProperty('namespacedAsset');
+      expect(ethpmURI.scheme).toEqual('erc1319');
+      expect(ethpmURI.address).toEqual('snakecharmers.eth');
+      expect(ethpmURI.chainId).toEqual(1);
+      expect(ethpmURI.packageName).toEqual('');
+      expect(ethpmURI.version).toEqual('');
+      expect(ethpmURI.namespacedAsset).toEqual('');
     },
   );
 });
@@ -27,24 +30,51 @@ describe('validates URIs', () => {
 
 describe('parses package names and versions', () => {
   const validPackageIdUris = [
-    'erc1319://snakecharmers.eth:1/dai@1.0.0',
-    'erc1319://snakecharmers.eth:1/dai@1.0.0/',
+    'ethpm://snakecharmers.eth:1/dai@1.0.0',
+    'ethpm://snakecharmers.eth:1/dai@1.0.0/',
   ];
 
   test.each(validPackageIdUris)(
     'for valid package URIs',
     (uri) => {
-      const erc1319URI = new Erc1319URI(uri);
-      expect(erc1319URI).toHaveProperty('scheme');
-      expect(erc1319URI).toHaveProperty('address');
-      expect(erc1319URI).toHaveProperty('chainId');
-      expect(erc1319URI).toHaveProperty('packageName');
-      expect(erc1319URI).toHaveProperty('version');
-      expect(erc1319URI.scheme).toEqual('erc1319');
-      expect(erc1319URI.address).toEqual('snakecharmers.eth');
-      expect(erc1319URI.chainId).toEqual(1);
-      expect(erc1319URI.packageName).toEqual('dai');
-      expect(erc1319URI.version).toEqual('1.0.0');
+      const ethpmURI = new EthpmURI(uri);
+      expect(ethpmURI).toHaveProperty('scheme');
+      expect(ethpmURI).toHaveProperty('address');
+      expect(ethpmURI).toHaveProperty('chainId');
+      expect(ethpmURI).toHaveProperty('packageName');
+      expect(ethpmURI).toHaveProperty('version');
+      expect(ethpmURI).toHaveProperty('namespacedAsset');
+      expect(ethpmURI.scheme).toEqual('ethpm');
+      expect(ethpmURI.address).toEqual('snakecharmers.eth');
+      expect(ethpmURI.chainId).toEqual(1);
+      expect(ethpmURI.packageName).toEqual('dai');
+      expect(ethpmURI.version).toEqual('1.0.0');
+    },
+  );
+});
+
+describe('supports namespaced assets', () => {
+  const validPackageIdUris = [
+    'ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken',
+    'ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken/',
+  ];
+
+  test.each(validPackageIdUris)(
+    'for valid package URIs',
+    (uri) => {
+      const ethpmURI = new EthpmURI(uri);
+      expect(ethpmURI).toHaveProperty('scheme');
+      expect(ethpmURI).toHaveProperty('address');
+      expect(ethpmURI).toHaveProperty('chainId');
+      expect(ethpmURI).toHaveProperty('packageName');
+      expect(ethpmURI).toHaveProperty('version');
+      expect(ethpmURI).toHaveProperty('namespacedAsset');
+      expect(ethpmURI.scheme).toEqual('ethpm');
+      expect(ethpmURI.address).toEqual('snakecharmers.eth');
+      expect(ethpmURI.chainId).toEqual(1);
+      expect(ethpmURI.packageName).toEqual('dai');
+      expect(ethpmURI.version).toEqual('1.0.0');
+      expect(ethpmURI.namespacedAsset).toEqual('deployments/DSToken');
     },
   );
 });
@@ -64,14 +94,12 @@ describe('invalidates ', () => {
     'invalid uri schemes',
     (uri) => {
       expect(() => {
-        new Erc1319URI(uri);
+        new EthpmURI(uri);
       }).toThrow('Invalid scheme: ');
     },
   );
 
   const invalidChainIds = [
-    'erc1319://snakecharmers.eth',
-    'erc1319://snakecharmers.eth/',
     'erc1319://snakecharmers.eth:2',
     'erc1319://snakecharmers.eth:2/',
     'erc1319://snakecharmers.eth:41',
@@ -81,7 +109,7 @@ describe('invalidates ', () => {
     'invalid chain IDs',
     (uri) => {
       expect(() => {
-        new Erc1319URI(uri);
+        new EthpmURI(uri);
       }).toThrow('Invalid chain ID: ');
     },
   );
@@ -97,7 +125,7 @@ describe('invalidates ', () => {
     'invalid package IDs',
     (uri) => {
       expect(() => {
-        new Erc1319URI(uri);
+        new EthpmURI(uri);
       }).toThrow('Invalid package ID: ');
     },
   );

--- a/src/utils/test/uri.ts
+++ b/src/utils/test/uri.ts
@@ -1,22 +1,26 @@
 import { EthpmURI } from 'ethpm/utils/uri';
+import { URL } from 'url';
 
 describe('validates URIs', () => {
   const validRegistryUris = [
     'erc1319://snakecharmers.eth',
     'erc1319://snakecharmers.eth:1',
     'erc1319://snakecharmers.eth:1/',
+    new URL('erc1319://snakecharmers.eth:1/'),
   ];
 
   test.each(validRegistryUris)(
     'for valid registry URIs',
     (uri) => {
       const ethpmURI = new EthpmURI(uri);
+      expect(ethpmURI).toHaveProperty('raw');
       expect(ethpmURI).toHaveProperty('scheme');
       expect(ethpmURI).toHaveProperty('address');
       expect(ethpmURI).toHaveProperty('chainId');
       expect(ethpmURI).toHaveProperty('packageName');
       expect(ethpmURI).toHaveProperty('version');
       expect(ethpmURI).toHaveProperty('namespacedAsset');
+      expect(ethpmURI.raw).toEqual(uri);
       expect(ethpmURI.scheme).toEqual('erc1319');
       expect(ethpmURI.address).toEqual('snakecharmers.eth');
       expect(ethpmURI.chainId).toEqual(1);
@@ -32,18 +36,21 @@ describe('parses package names and versions', () => {
   const validPackageIdUris = [
     'ethpm://snakecharmers.eth:1/dai@1.0.0',
     'ethpm://snakecharmers.eth:1/dai@1.0.0/',
+    new URL('ethpm://snakecharmers.eth:1/dai@1.0.0/'),
   ];
 
   test.each(validPackageIdUris)(
     'for valid package URIs',
     (uri) => {
       const ethpmURI = new EthpmURI(uri);
+      expect(ethpmURI).toHaveProperty('raw');
       expect(ethpmURI).toHaveProperty('scheme');
       expect(ethpmURI).toHaveProperty('address');
       expect(ethpmURI).toHaveProperty('chainId');
       expect(ethpmURI).toHaveProperty('packageName');
       expect(ethpmURI).toHaveProperty('version');
       expect(ethpmURI).toHaveProperty('namespacedAsset');
+      expect(ethpmURI.raw).toEqual(uri);
       expect(ethpmURI.scheme).toEqual('ethpm');
       expect(ethpmURI.address).toEqual('snakecharmers.eth');
       expect(ethpmURI.chainId).toEqual(1);
@@ -57,18 +64,21 @@ describe('supports namespaced assets', () => {
   const validPackageIdUris = [
     'ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken',
     'ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken/',
+    new URL('ethpm://snakecharmers.eth:1/dai@1.0.0/deployments/DSToken/'),
   ];
 
   test.each(validPackageIdUris)(
     'for valid package URIs',
     (uri) => {
       const ethpmURI = new EthpmURI(uri);
+      expect(ethpmURI).toHaveProperty('raw');
       expect(ethpmURI).toHaveProperty('scheme');
       expect(ethpmURI).toHaveProperty('address');
       expect(ethpmURI).toHaveProperty('chainId');
       expect(ethpmURI).toHaveProperty('packageName');
       expect(ethpmURI).toHaveProperty('version');
       expect(ethpmURI).toHaveProperty('namespacedAsset');
+      expect(ethpmURI.raw).toEqual(uri);
       expect(ethpmURI.scheme).toEqual('ethpm');
       expect(ethpmURI.address).toEqual('snakecharmers.eth');
       expect(ethpmURI.chainId).toEqual(1);

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -16,8 +16,8 @@ export class EthpmURI {
   version: string;
   namespacedAsset: string;
 
-  constructor(uri: string | URL) {
-    const parsedURI = typeof uri === 'string' ? new URL(uri) : uri;
+  constructor(uri: string) {
+    const parsedURI = new URL(uri);
     this.raw = uri;
     this.scheme = EthpmURI.parseScheme(parsedURI);
     this.chainId = EthpmURI.parseChainId(parsedURI);

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -7,25 +7,20 @@ import { URL } from 'url';
 // scheme://address:chainId/packageName@version
 // i.e.
 // erc1319://snakecharmers.eth:1/dai@1.0.0
-export class Erc1319URI {
+export class EthpmURI {
   scheme: string;
-
   address: string;
-
   chainId: number;
-
   packageName: string;
-
   version: string;
+  namespacedAsset: string;
 
   constructor(uri: string | URL) {
     const parsedUri = typeof uri === 'string' ? new URL(uri) : uri;
-    this.scheme = Erc1319URI.parseScheme(parsedUri);
-    this.chainId = Erc1319URI.parseChainId(parsedUri);
+    this.scheme = EthpmURI.parseScheme(parsedUri);
+    this.chainId = EthpmURI.parseChainId(parsedUri);
     this.address = parsedUri.hostname; // address or ensName
-    const packageId = Erc1319URI.parsePackageId(parsedUri);
-    this.packageName = packageId[0];
-    this.version = packageId[1];
+    [this.packageName, this.version, this.namespacedAsset] = EthpmURI.parsePackageId(parsedUri);
   }
 
   static parsePackageId(url: URL) {
@@ -38,30 +33,32 @@ export class Erc1319URI {
           `Invalid package ID: ${packageId}. URI must include both a package name and version.`,
         );
       } else {
-        return packageId;
+        let [packageName, version] = packageId
+        let namespacedAsset = pathElements.splice(1).join("/")
+        return [packageName, version, namespacedAsset];
       }
     } else {
-      return ['', ''];
+      return ['', '', ''];
     }
   }
 
   static parseChainId(url: URL) {
     // todo: support multiple chain ids
     const chainId = +url.port;
-    if (chainId !== 1) {
+    if (chainId === 1 || chainId === 0) {
+      return 1;
+    } else {
       throw new Error(
         `Invalid chain ID: ${chainId}. Currently only mainnet is supported.`,
       );
-    } else {
-      return chainId;
     }
   }
 
   static parseScheme(url: URL) {
     const scheme = url.protocol.replace(/:+$/, '');
-    if (scheme !== 'erc1319') {
+    if (scheme !== 'erc1319' && scheme !== 'ethpm') {
       throw new Error(
-        `Invalid scheme: ${scheme} found on uri: ${url}. Expected scheme to match "erc1319".`,
+        `Invalid scheme: ${scheme} found on uri: ${url}. Expected scheme to match "ethpm" or "erc1319".`,
       );
     } else {
       return scheme;

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -8,6 +8,7 @@ import { URL } from 'url';
 // i.e.
 // erc1319://snakecharmers.eth:1/dai@1.0.0
 export class EthpmURI {
+  raw: string;
   scheme: string;
   address: string;
   chainId: number;
@@ -16,11 +17,12 @@ export class EthpmURI {
   namespacedAsset: string;
 
   constructor(uri: string | URL) {
-    const parsedUri = typeof uri === 'string' ? new URL(uri) : uri;
-    this.scheme = EthpmURI.parseScheme(parsedUri);
-    this.chainId = EthpmURI.parseChainId(parsedUri);
-    this.address = parsedUri.hostname; // address or ensName
-    [this.packageName, this.version, this.namespacedAsset] = EthpmURI.parsePackageId(parsedUri);
+    const parsedURI = typeof uri === 'string' ? new URL(uri) : uri;
+    this.raw = uri;
+    this.scheme = EthpmURI.parseScheme(parsedURI);
+    this.chainId = EthpmURI.parseChainId(parsedURI);
+    this.address = parsedURI.hostname; // address or ensName
+    [this.packageName, this.version, this.namespacedAsset] = EthpmURI.parsePackageId(parsedURI);
   }
 
   static parsePackageId(url: URL) {


### PR DESCRIPTION
Updated the ethpm uri parser to...
- support default chain ids of `1`
- support the `ethpm` scheme