### PR TITLE
Parse truffle artifacts that might be missing default fields

### DIFF
--- a/src/utils/test/assets/Minimal.json
+++ b/src/utils/test/assets/Minimal.json
@@ -1,0 +1,35 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "conversionRate",
+          "type": "uint256"
+        }
+      ],
+      "name": "convert",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "convertedAmount",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    }
+  ],
+  "contractName": "ConvertLib",
+  "networkType": "ethereum",
+  "networks": {},
+  "schemaVersion": "3.0.19",
+  "updatedAt": "2020-01-20T09:35:09.830Z"
+}

--- a/src/utils/test/truffle.ts
+++ b/src/utils/test/truffle.ts
@@ -3,6 +3,7 @@ import { parseTruffleArtifacts } from 'ethpm/utils/truffle';
 import { Package } from 'ethpm/package';
 const fs = require("fs");
 
+
 // MetaCoin deployed bytecode in artifact is not accurate, but adjusted for testing multiple linkrefs
 describe('handles truffle artifacts', () => {
   it(`for an iterator of artifact files: ctypes & deployments`, async() => {
@@ -42,4 +43,11 @@ describe('handles truffle artifacts', () => {
     const secondPkg = await v2.read(actualManifest)
     expect(pkg).toEqual(secondPkg)
   })
+
+
+  it('for artifacts that are installed via ethpm, w/o all default fields', async() => {
+    const artifact = JSON.parse(fs.readFileSync(`./src/utils/test/assets/Minimal.json`, 'utf8'))
+    const artifactConfig = await parseTruffleArtifacts([artifact])
+    expect(artifactConfig).toEqual({"contract_types": {"ConvertLib": { "abi": artifact.abi}}})
+  });
 });


### PR DESCRIPTION
In truffle, is a package is installed via ethpm and saved in the artifactor - it won't necessarily save the same default fields as if it was a local contract that was compiled. So to be able to include installed ethpm packages when publishing, we have to allow for some missing fields.